### PR TITLE
X-Retry-Counter header

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,17 @@ until giving up after 10 attempts.
 
 The following options are available:
 
-| Option                             | Type              | Default  | Summary |
-| ---------------------------------- | ----------------- | -------- | ------- |
-| `retry_enabled`                    | boolean           | true     | Is retry enabled (useful for disabling for individual requests)
-| `max_retry_attempts`               | integer           | 10       | Maximum number of retries per request
-| `retry_only_if_retry_after_header` | boolean           | false    | Retry only if `RetryAfter` header sent
-| `retry_on_status`                  | array<int>        | 503, 429 | The response status codes that will trigger a retry
-| `default_retry_multiplier`         | float or callable | 1.5      | Value to multiply the number of requests by if `RetryAfter` not supplied (see [below](#setting-default-retry-delay) for details)
-| `on_retry_callback`                | callable          | null     | Optional callback to call when a retry occurs
-| `retry_on_timeout`                 | boolean           | false    | Set to TRUE if you wish to retry requests that timeout (configured with `connect_timeout` or `timeout` options)
+| Option                             | Type              | Default         | Summary |
+| ---------------------------------- | ----------------- | --------------- | ------- |
+| `retry_enabled`                    | boolean           | true            | Is retry enabled (useful for disabling for individual requests)
+| `max_retry_attempts`               | integer           | 10              | Maximum number of retries per request
+| `retry_only_if_retry_after_header` | boolean           | false           | Retry only if `RetryAfter` header sent
+| `retry_on_status`                  | array<int>        | 503, 429        | The response status codes that will trigger a retry
+| `default_retry_multiplier`         | float or callable | 1.5             | Value to multiply the number of requests by if `RetryAfter` not supplied (see [below](#setting-default-retry-delay) for details)
+| `on_retry_callback`                | callable          | null            | Optional callback to call when a retry occurs
+| `retry_on_timeout`                 | boolean           | false           | Set to TRUE if you wish to retry requests that timeout (configured with `connect_timeout` or `timeout` options)
+| `expose_retry_header`              | boolean           | false           | Set to TRUE if you wish to expose the number of retries as a header on the response object
+| `retry_header`                     | string            | X-Retry-Counter | The header key to use
 
 Each option is discussed in detail below.
 


### PR DESCRIPTION
## Description

Add the option to include an X header indicating the number of retries used

## Motivation and context

This helps for debugging purposes.

## How has this been tested?

Unit tests and local project

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask.
