### PR TITLE
Fix for example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ use GuzzleRetry\GuzzleRetryMiddleware;
 $stack = HandlerStack::create();
 $stack->push(GuzzleRetryMiddleware::factory());
 
-$client = new Client([$stack]);
+$client = new Client(['handler' => $stack]);
 
 // Make requests galore...
 


### PR DESCRIPTION
Fix for example code in README.md
The first example is missing the 'handler' key in the client options array. 