### PR TITLE
Allow request and options to be modified within the callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ reporting, or anything else you can think of.
 
 If you specify a callback, it will be called before the middleware calls the `usleep()` delay function.
 
+The `request` and `options` arguments are sent by reference in case you want to modify them in the callback.
+
 ```php
 
 use Psr\Http\Message\RequestInterface;
@@ -259,7 +261,7 @@ use Psr\Http\Message\ResponseInterface;
  * @param array                  $options        Guzzle request options
  * @param ResponseInterface|null $response       Response (or NULL if response not sent; e.g. connect timeout)
  */
-$listener = function($attemptNumber, $delay, $request, $options, $response) {
+$listener = function($attemptNumber, $delay, &$request, &$options, $response) {
     
     echo sprintf(
         "Retrying request to %s.  Server responded with %s.  Will wait %s seconds.  This is attempt #%s,

--- a/src/GuzzleRetryMiddleware.php
+++ b/src/GuzzleRetryMiddleware.php
@@ -268,13 +268,15 @@ class GuzzleRetryMiddleware
 
         // Callback?
         if ($options['on_retry_callback']) {
-            \call_user_func(
+            \call_user_func_array(
                 $options['on_retry_callback'],
-                (int) $options['retry_count'],
-                (float) $delayTimeout,
-                $request,
-                $options,
-                $response
+                [
+                    (int) $options['retry_count'],
+                    (float) $delayTimeout,
+                    &$request,
+                    &$options,
+                    $response
+                ]
             );
         }
 


### PR DESCRIPTION
## Description

This allows you to modify the request and options if need be inside the retry callback.

## Motivation and context

This is useful for any cases where headers need to change between retries. One example would be to change the "Authorization" header between retries when responding to 401 HTTP errors.

## How has this been tested?

`composer test` was used to test for changes. Does not affect any other areas as it just adds the possibility to use request and options as references in the callback.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask.
