### PR TITLE
Adds new option `request_after_header` to specify custom retry after header name

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The following options are available:
 | `retry_on_timeout`                 | boolean           | false           | Set to TRUE if you wish to retry requests that timeout (configured with `connect_timeout` or `timeout` options)
 | `expose_retry_header`              | boolean           | false           | Set to TRUE if you wish to expose the number of retries as a header on the response object
 | `retry_header`                     | string            | X-Retry-Counter | The header key to use for the retry counter (if you need it)
+| `retry_after_header`               | string            | Retry-After     | The header key to use for the retry after header.
 
 Each option is discussed in detail below.
 
@@ -332,6 +333,18 @@ $response = $client->get('/some-path', [
 
 # If a request was retried, the response will include the 'X-Retry-Counter'
 $numRetries = (int) $response->getHeaderLine('X-Retry-Count');
+```
+
+### Modifying the default retry after header
+
+```php
+# Change the name of the expected retry after header to something else:
+$response = $client->get('/some-path', [
+    'retry_after_header' => 'X-Custom-Retry-After-Seconds'
+]);
+
+# Otherwise, the default `Retry-After` header will be used.
+$response = $client->get('/some-path');
 ```
 
 ## Change log

--- a/src/GuzzleRetryMiddleware.php
+++ b/src/GuzzleRetryMiddleware.php
@@ -50,6 +50,9 @@ class GuzzleRetryMiddleware
     // Default retry header (off by default; configurable)
     public const RETRY_HEADER = 'X-Retry-Counter';
 
+    // Default retry-after header
+    public const RETRY_AFTER_HEADER = 'Retry-After';
+
     /**
      * @var array
      */
@@ -81,7 +84,10 @@ class GuzzleRetryMiddleware
         'expose_retry_header'              => false,
 
         // The header key
-        'retry_header'                     => self::RETRY_HEADER
+        'retry_header'                     => self::RETRY_HEADER,
+
+        // The retry after header key
+        'retry_after_header'               => self::RETRY_AFTER_HEADER,
     ];
 
     /**
@@ -307,7 +313,7 @@ class GuzzleRetryMiddleware
     /**
      * Determine the delay timeout
      *
-     * Attempts to read and interpret the HTTP `Retry-After` header, or defaults
+     * Attempts to read and interpret the configured retry after header, or defaults
      * to a built-in incremental back-off algorithm.
      *
      * @param ResponseInterface $response
@@ -328,9 +334,9 @@ class GuzzleRetryMiddleware
 
         // Retry-After can be a delay in seconds or a date
         // (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After)
-        if ($response && $response->hasHeader('Retry-After')) {
+        if ($response && $response->hasHeader($options['retry_after_header'])) {
             return
-                $this->deriveTimeoutFromHeader($response->getHeader('Retry-After')[0])
+                $this->deriveTimeoutFromHeader($response->getHeader($options['retry_after_header'])[0])
                 ?: $defaultDelayTimeout;
         }
 
@@ -338,7 +344,7 @@ class GuzzleRetryMiddleware
     }
 
     /**
-     * Attempt to derive the timeout from the HTTP `Retry-After` header
+     * Attempt to derive the timeout from the provided retry after header value
      *
      * The spec allows the header value to either be a number of seconds or a datetime.
      *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Provides ability to override the name of the `Retry-After` header to something else, in case an API doesn't use the standard header names.

## Motivation and context

I'm currently consuming an API that sets a custom `Retry-After` -esque header and I'd like to be able to use this library if possible!

## How has this been tested?

Added an additional unit test that ensures the proper timeouts are derived from a custom header if the option is specified.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [X] I have added tests to cover my changes.
- [X] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask.

re: the CHANGELOG, I wasn't sure if I was supposed to update that in my PR, so I left it alone for now.
