### PR TITLE
Fix microsecond delays

### DIFF
--- a/src/GuzzleRetryMiddleware.php
+++ b/src/GuzzleRetryMiddleware.php
@@ -355,7 +355,7 @@ class GuzzleRetryMiddleware
     {
         // The timeout will either be a number or a HTTP-formatted date,
         // or seconds (integer)
-        if (trim($headerValue) === (string) (int) $headerValue) {
+        if (is_numeric($headerValue)) {
             return (float) trim($headerValue);
         } elseif ($date = DateTime::createFromFormat(self::DATE_FORMAT, trim($headerValue))) {
             return (float) $date->format('U') - time();


### PR DESCRIPTION
This change fixes the issue where if a server returns a decimal Retry-After, for example sub-second delays, the client will not have to wait until the next full second to retry the request. The previous code would first round the delay to the nearest integer (integer type-cast) and THEN convert to microseconds. However to retain the decimal precision, we should first convert to microseconds and THEN cast to an integer.

In addition, the code to parse the Retry-After header has been fixed to parse fractional seconds (microseconds).