### PR TITLE
Include RequestInterface as argument in should_retry_callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All Notable changes to `guzzle_retry_middleware` will be documented in this file
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [Unreleased]
+### Added
+- Include RequestInterface as  [`should_retry_callback` argument](./README.md#custom-retry-decision-logic) when triggered.
+
 ## [2.10.0] (2024-06-19)
 ### Added
 - Include [`on_retry_callback` argument]() when triggered by `onRejected` (thanks @ViktorCollin)

--- a/README.md
+++ b/README.md
@@ -429,6 +429,9 @@ consider a server that returns a `200` status code, but with a message body inst
 you can use the `should_retry_callback` option to implement a callback method that returns `true` (should retry) or `false` 
 (should not retry).
 
+Another use for this callback could be based on the request itself.
+For example, you may only want to retry requests that have a specific header set.
+
 It's important to note that the callback will be called only if all the following circumstances are true:
 
 * The `retry_enabled` option is `true` (default: `true`)
@@ -436,10 +439,16 @@ It's important to note that the callback will be called only if all the followin
 * The total time elapsed is less than the `give_up_after_secs` value (default: _disabled_)
 
 ```php
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 
-$callback = function (array $options, ?ResponseInterface $response = null): bool {
+$callback = function (array $options, ?ResponseInterface $response, RequestInterface $request): bool {
+    // Only allow retries if x-header header is set
+    if(! $request->hasHeader('x-header')) {
+        return false; 
+    }
+
     // Response will be NULL in the event of a connection timeout, so your callback function
     // will need to be able to handle that case
     if (! $response) {

--- a/src/GuzzleRetryMiddleware.php
+++ b/src/GuzzleRetryMiddleware.php
@@ -299,7 +299,7 @@ class GuzzleRetryMiddleware
 
             // Has 'should_retry_callback' option?
             case $options['should_retry_callback']:
-                return (bool) call_user_func($options['should_retry_callback'], $options, $response);
+                return (bool) call_user_func($options['should_retry_callback'], $options, $response, $request);
 
             // No Retry-After header, and it is required?  Give up!
             // (note: this has to be after the 'should_retry_callback' case)


### PR DESCRIPTION
Added RequestInterface as argument to the should_retry_callback

## Description

Make it possible to use request based values to decide if retry should happen or not.

## Motivation and context

By adding the `RequestInterface` it's now possible to use the `should_retry_callback` to only retry based on headers in the request.
An example would be to only retry if against a remote api that implement "Idempotency" based on unique token in request headers, but only for non-GET requests.
So if it's a POST request and the request header is set, then it can be safely retried.

## How has this been tested?

Updated unit tests to include the new argument and use of it

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask.
