### PR TITLE
fixed no blocking delay

### DIFF
--- a/src/GuzzleRetryMiddleware.php
+++ b/src/GuzzleRetryMiddleware.php
@@ -164,7 +164,8 @@ class GuzzleRetryMiddleware
             
             $options['first_request_timestamp'] = time();
         } else {
-            $delay = $options['delay'] ? (int) ($options['delay'] / 1000) : 0;
+            $delay = (isset($options['delay']) && is_int($options['delay'])) ? 
+                (int) ($options['delay'] / 1000) : 0;
             $options['request_timestamp'] += $delay;
         }
 
@@ -368,7 +369,7 @@ class GuzzleRetryMiddleware
 
         // Init delay
         // https://docs.guzzlephp.org/en/stable/request-options.html#delay
-       $options['delay'] = (int) ($delayTimeout * 1e3));
+        $options['delay'] = (int) ($delayTimeout * 1e3);
 
         // Callback?
         if ($options['on_retry_callback']) {

--- a/src/GuzzleRetryMiddleware.php
+++ b/src/GuzzleRetryMiddleware.php
@@ -363,6 +363,10 @@ class GuzzleRetryMiddleware
         // Determine the delay timeout
         $delayTimeout = $this->determineDelayTimeout($options, $response);
 
+        // Init delay
+        // https://docs.guzzlephp.org/en/stable/request-options.html#delay
+       $options['delay'] = (int) ($delayTimeout * 1e3));
+
         // Callback?
         if ($options['on_retry_callback']) {
             call_user_func_array(
@@ -377,9 +381,6 @@ class GuzzleRetryMiddleware
                 ]
             );
         }
-
-        // Delay!
-        usleep((int) ($delayTimeout * 1e6));
 
         // Return
         return $this($request, $options);

--- a/src/GuzzleRetryMiddleware.php
+++ b/src/GuzzleRetryMiddleware.php
@@ -159,14 +159,12 @@ class GuzzleRetryMiddleware
         }
 
         if ($options['retry_count'] === 0) {
-            // Set the request timestamp as far as we know it
             $options['request_timestamp'] = time();
-            
             $options['first_request_timestamp'] = time();
         } else {
             $delay = (isset($options['delay']) && is_int($options['delay'])) ? 
                 (int) ($options['delay'] / 1000) : 0;
-            $options['request_timestamp'] += $delay;
+            $options['request_timestamp'] = time() + $delay;
         }
 
         $next = $this->nextHandler;

--- a/src/GuzzleRetryMiddleware.php
+++ b/src/GuzzleRetryMiddleware.php
@@ -153,16 +153,19 @@ class GuzzleRetryMiddleware
         // Combine options with defaults specified by this middleware
         $options = array_replace($this->defaultOptions, $options);
 
-        // Set the request timestamp as far as we know it
-        $options['request_timestamp'] = time();
-
         // Set the retry counter if not already set
         if (! isset($options['retry_count'])) {
             $options['retry_count'] = 0;
         }
 
         if ($options['retry_count'] === 0) {
+            // Set the request timestamp as far as we know it
+            $options['request_timestamp'] = time();
+            
             $options['first_request_timestamp'] = time();
+        } else {
+            $delay = $options['delay'] ? (int) ($options['delay'] / 1000) : 0;
+            $options['request_timestamp'] += $delay;
         }
 
         $next = $this->nextHandler;


### PR DESCRIPTION
In the current implementation, using usleep() causes the execution thread of asynchronous requests to be blocked.
https://docs.guzzlephp.org/en/stable/quickstart.html#async-requests

This fix resolves the issue.